### PR TITLE
ci: Add multi-arch docker build support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,25 +10,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
+          
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: swetrix/swetrix-fe
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
### Description

- Adds support for multi architecture docker builds in amd64 and arm64
- Related with: https://github.com/Swetrix/swetrix-api/pull/237

Just did a test build run, available [here on my docker hub](https://hub.docker.com/repository/docker/dinip/swetrix-api/tags) and seems like the multi-arch worked. Also tested on my arm machine and it works as it should.

![docker_hub_build_tags](https://github.com/Swetrix/swetrix-fe/assets/8941012/be827643-02b8-474b-9ef4-55ce921580e6)

Note: not sure if you have a specific reason to have the actions version pinned or not, but if you want them pinned to the hash, let me know and I'll revert those changes.